### PR TITLE
README: Mention react-native link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ It run good on:
 git clone https://github.com/thanhtungdp/react-native-login-animated
 cd react-native-login-animated
 npm install
-rnpm link #auto linked libs to Xcode, or Android
-react-native run-ios # Run ios simulator
-react-native run-android # Run android simulator
+react-native link # Auto link libs to Xcode, or Android
+react-native run-ios # Run app on iOS simulator
+react-native run-android # Run app on Android emulator
 ```
 
 # Tutorial step by step


### PR DESCRIPTION
rnpm is now part of React Native itself, see the explanation if curious: https://github.com/rnpm/rnpm

This updates the readme. But if you want to make this even easier, you could:
- Run 'react-native link' locally, this updates Xcode project files and Android build.gradle files
- Commit the updates files

This way, you can remove the 'react-native link' step from the readme completely.